### PR TITLE
Add shared dark mode toggle across site

### DIFF
--- a/admin-dashboard.html
+++ b/admin-dashboard.html
@@ -69,7 +69,13 @@
                 <!-- Admin management tab only visible to super admins -->
                 <a href="#admin-management" id="admin-management-link" data-tab="admin-management" class="admin-nav-link text-gray-700 dark-mode:text-gray-300 hover:text-purple-600 transition-all duration-300 hidden">Admin Management</a>
             </div>
-            <button id="admin-logout" class="bg-gradient-to-r from-purple-500 to-orange-400 text-white px-4 py-2 rounded-lg font-medium hover:from-purple-600 hover:to-orange-500 transition">Logout</button>
+            <div class="flex items-center space-x-4">
+                <button id="dark-mode-toggle" class="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors text-gray-700 dark:text-gray-200" aria-label="Toggle dark mode">
+                    <svg id="icon-moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.718 9.718 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 009.002-5.998z" /></svg>
+                    <svg id="icon-sun" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="w-6 h-6 hidden"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z" /></svg>
+                </button>
+                <button id="admin-logout" class="bg-gradient-to-r from-purple-500 to-orange-400 text-white px-4 py-2 rounded-lg font-medium hover:from-purple-600 hover:to-orange-500 transition">Logout</button>
+            </div>
         </div>
     </nav>
 
@@ -910,5 +916,6 @@
             showTab('analytics');
         });
     </script>
+    <script src="dark-mode.js"></script>
 </body>
 </html>

--- a/admin-login.html
+++ b/admin-login.html
@@ -57,7 +57,11 @@
                 <span class="text-xl font-extrabold bg-gradient-to-r from-purple-500 to-orange-400 bg-clip-text text-transparent">AHELP</span>
             </a>
         </div>
-        <div>
+        <div class="flex items-center space-x-4">
+            <button id="dark-mode-toggle" class="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors text-gray-700 dark:text-gray-200" aria-label="Toggle dark mode">
+                <svg id="icon-moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.718 9.718 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 009.002-5.998z" /></svg>
+                <svg id="icon-sun" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="w-6 h-6 hidden"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z" /></svg>
+            </button>
             <a href="index.html" class="text-gray-600 hover:text-purple-600 text-sm">← Back to Home</a>
         </div>
     </nav>
@@ -119,9 +123,10 @@
                 localStorage.setItem('isSuperAdmin', agency === 'all' ? 'true' : 'false');
                 window.location.href = 'admin-dashboard.html';
             } else {
-                document.getElementById('admin-error').classList.remove('hidden');
-            }
-        });
+        document.getElementById('admin-error').classList.remove('hidden');
+        }
+    });
     </script>
+    <script src="dark-mode.js"></script>
 </body>
 </html>

--- a/challenges.html
+++ b/challenges.html
@@ -86,11 +86,17 @@
                 <a href="settings.html" class="text-1xl font-extrabold bg-gradient-to-r from-purple-400 to-orange-300 bg-clip-text text-transparent">Settings</a>
                 <a href="redeem.html" class="text-1xl font-extrabold bg-gradient-to-r from-purple-400 to-orange-300 bg-clip-text text-transparent">Redeem</a>
             </div>
-            <button id="mobile-btn" class="md:hidden text-gray-700 focus:outline-none">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-                </svg>
-            </button>
+            <div class="flex items-center space-x-4">
+                <button id="dark-mode-toggle" class="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors text-gray-700 dark:text-gray-200" aria-label="Toggle dark mode">
+                    <svg id="icon-moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.718 9.718 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 009.002-5.998z" /></svg>
+                    <svg id="icon-sun" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="w-6 h-6 hidden"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z" /></svg>
+                </button>
+                <button id="mobile-btn" class="md:hidden text-gray-700 focus:outline-none">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+                    </svg>
+                </button>
+            </div>
         </div>
         <div id="mobile-menu" class="md:hidden hidden px-4 pb-4">
             <a href="home.html" class="block py-2 text-gray-700 hover:text-purple-600">Home</a>
@@ -203,6 +209,7 @@
         <div class="mt-8 text-center text-gray-500">© 2025 Arkansas Shared Administrative Services. All rights reserved.</div>
     </footer>
 
+    <script src="dark-mode.js"></script>
     <!-- Mobile menu script -->
     <script>
         document.getElementById('mobile-btn').addEventListener('click', () => {
@@ -211,15 +218,9 @@
     </script>
     <!-- Back to Top Button -->
     <button id="back-to-top" class="hidden fixed bottom-6 right-6 p-3 rounded-full bg-purple-500 text-white shadow-lg" aria-label="Back to top">↑</button>
-    <!-- Dark Mode Persistence & Back‑to‑Top Script -->
+    <!-- Back‑to‑Top Script -->
     <script>
       document.addEventListener('DOMContentLoaded', function() {
-        // Apply saved dark mode from localStorage if enabled
-        try {
-          if (localStorage.getItem('darkMode') === 'true') {
-            document.body.classList.add('dark-mode');
-          }
-        } catch (e) {}
         const backBtn = document.getElementById('back-to-top');
         window.addEventListener('scroll', function() {
           if (window.scrollY > 200) {

--- a/community.html
+++ b/community.html
@@ -68,11 +68,17 @@
                 <a href="settings.html" class="text-1xl font-extrabold bg-gradient-to-r from-purple-400 to-orange-300 bg-clip-text text-transparent">Settings</a>
                 <a href="redeem.html" class="text-1xl font-extrabold bg-gradient-to-r from-purple-400 to-orange-300 bg-clip-text text-transparent">Redeem</a>
             </div>
-            <button id="mobile-btn" class="md:hidden text-gray-700 focus:outline-none">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-                </svg>
-            </button>
+            <div class="flex items-center space-x-4">
+                <button id="dark-mode-toggle" class="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors text-gray-700 dark:text-gray-200" aria-label="Toggle dark mode">
+                    <svg id="icon-moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.718 9.718 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 009.002-5.998z" /></svg>
+                    <svg id="icon-sun" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="w-6 h-6 hidden"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z" /></svg>
+                </button>
+                <button id="mobile-btn" class="md:hidden text-gray-700 focus:outline-none">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+                    </svg>
+                </button>
+            </div>
         </div>
         <div id="mobile-menu" class="md:hidden hidden px-4 pb-4">
             <a href="index.html" class="block py-2 text-gray-700 hover:text-purple-600">Home</a>
@@ -164,16 +170,11 @@
             document.getElementById('mobile-menu').classList.toggle('hidden');
         });
     </script>
-    <!-- Back to Top Button -->
+      <!-- Back to Top Button -->
     <button id="back-to-top" class="hidden fixed bottom-6 right-6 p-3 rounded-full bg-purple-500 text-white shadow-lg" aria-label="Back to top">↑</button>
-    <!-- Dark Mode Persistence & Back‑to‑Top Script -->
+    <!-- Back‑to‑Top Script -->
     <script>
       document.addEventListener('DOMContentLoaded', function() {
-        try {
-          if (localStorage.getItem('darkMode') === 'true') {
-            document.body.classList.add('dark-mode');
-          }
-        } catch (e) {}
         const backBtn = document.getElementById('back-to-top');
         window.addEventListener('scroll', function() {
           if (window.scrollY > 200) {
@@ -225,13 +226,8 @@
             }
         });
 
-        // Dark mode and back to top
+        // Back to top
         document.addEventListener('DOMContentLoaded', function () {
-            try {
-                if (localStorage.getItem('darkMode') === 'true') {
-                    document.body.classList.add('dark-mode');
-                }
-            } catch (e) {}
             const backBtn = document.getElementById('back-to-top');
             window.addEventListener('scroll', function () {
                 if (window.scrollY > 200) {
@@ -245,5 +241,6 @@
             });
         });
     </script>
+    <script src="dark-mode.js"></script>
 </body>
 </html>

--- a/dark-mode.js
+++ b/dark-mode.js
@@ -1,0 +1,34 @@
+// Shared dark mode toggle logic
+(function() {
+  function applyDarkMode(isDark) {
+    document.body.classList.toggle('dark-mode', isDark);
+    document.documentElement.classList.toggle('dark-mode', isDark);
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    var toggle = document.getElementById('dark-mode-toggle');
+    if (!toggle) return;
+    var iconMoon = document.getElementById('icon-moon');
+    var iconSun = document.getElementById('icon-sun');
+    var isDark = false;
+    try {
+      isDark = localStorage.getItem('darkMode') === 'true';
+    } catch (e) {}
+    applyDarkMode(isDark);
+    if (iconMoon && iconSun) {
+      iconMoon.classList.toggle('hidden', isDark);
+      iconSun.classList.toggle('hidden', !isDark);
+    }
+    toggle.addEventListener('click', function () {
+      isDark = !document.documentElement.classList.contains('dark-mode');
+      applyDarkMode(isDark);
+      try {
+        localStorage.setItem('darkMode', isDark);
+      } catch (e) {}
+      if (iconMoon && iconSun) {
+        iconMoon.classList.toggle('hidden', isDark);
+        iconSun.classList.toggle('hidden', !isDark);
+      }
+    });
+  });
+})();

--- a/dashboard.html
+++ b/dashboard.html
@@ -243,6 +243,14 @@
             100% { transform: scale(1) rotate(0deg); opacity: 1; }
         }
     </style>
+    <script>
+        try {
+            if (localStorage.getItem('darkMode') === 'true') {
+                document.documentElement.classList.add('dark-mode');
+                document.body.classList.add('dark-mode');
+            }
+        } catch (e) {}
+    </script>
 </head>
 <body class="bg-purple-100 transition-all duration-500">
     <!-- Particle Background -->
@@ -1525,7 +1533,6 @@
             activities: [],
             achievements: [],
             mood: 'good',
-            darkMode: false,
             level: 1,
             // Accumulated leave hours redeemed via the rewards programme
             leaveTime: 0
@@ -1588,20 +1595,6 @@
             if (userNameEl) {
                 userNameEl.textContent = userData.name;
             }
-            // Apply previously saved dark mode state
-            try {
-                const savedDark = localStorage.getItem('darkMode');
-                if (savedDark === 'true') {
-                    userData.darkMode = true;
-                    document.body.classList.add('dark-mode');
-                    const iconMoon = document.getElementById('icon-moon');
-                    const iconSun  = document.getElementById('icon-sun');
-                    if (iconMoon && iconSun) {
-                        iconMoon.classList.add('hidden');
-                        iconSun.classList.remove('hidden');
-                    }
-                }
-            } catch (e) {}
             // Immediately update the dashboard stats and visualisations when the page loads
             if (typeof updateDisplay === 'function') {
                 updateDisplay();
@@ -1713,30 +1706,7 @@
             });
         });
 
-        // Dark mode toggle
-        document.getElementById('dark-mode-toggle').addEventListener('click', () => {
-            // Flip the darkMode flag and apply/remove the dark mode class on the body
-            userData.darkMode = !userData.darkMode;
-            document.body.classList.toggle('dark-mode', userData.darkMode);
-            // Persist the dark mode preference so other pages stay in sync
-            try {
-                localStorage.setItem('darkMode', userData.darkMode);
-            } catch (e) {}
-
-            // Toggle visibility of the moon and sun icons; in light mode show the moon (meaning you can switch to dark)
-            const iconMoon = document.getElementById('icon-moon');
-            const iconSun  = document.getElementById('icon-sun');
-            if (userData.darkMode) {
-                iconMoon.classList.add('hidden');
-                iconSun.classList.remove('hidden');
-            } else {
-                iconMoon.classList.remove('hidden');
-                iconSun.classList.add('hidden');
-            }
-
-            // Show a toast letting the user know which mode is active
-            showEnhancedNotification(userData.darkMode ? 'Dark mode activated!' : 'Light mode activated!', 'info');
-        });
+        // Dark mode handled by shared script
 
         // Voice command (demo)
         document.getElementById('voice-command').addEventListener('click', () => {
@@ -3052,14 +3022,14 @@
             const darkThumb = document.getElementById('settings-dark-thumb');
             if (darkToggle) {
                 // Initialize toggle position based on current dark mode state
-                if (userData.darkMode) {
+                if (document.documentElement.classList.contains('dark-mode')) {
                     darkToggle.classList.add('bg-purple-600');
                     darkThumb.classList.add('translate-x-6');
                 }
                 darkToggle.addEventListener('click', () => {
                     // Trigger the existing dark mode toggle and update thumb appearance
                     document.getElementById('dark-mode-toggle').click();
-                    if (userData.darkMode) {
+                    if (document.documentElement.classList.contains('dark-mode')) {
                         darkToggle.classList.add('bg-purple-600');
                         darkThumb.classList.add('translate-x-6');
                     } else {
@@ -3157,6 +3127,7 @@
         <div class="mt-8 text-center text-gray-500">© 2025 Arkansas Shared Administrative Services. All rights reserved.</div>
     </footer>
 
+<script src="dark-mode.js"></script>
 <!-- Script to handle mobile navigation toggle on the dashboard -->
 <script>
     document.getElementById('mobile-menu-button').addEventListener('click', () => {

--- a/health-assessment.html
+++ b/health-assessment.html
@@ -64,7 +64,11 @@
                 <span class="text-2xl font-bold bg-gradient-to-r from-purple-500 to-orange-400 bg-clip-text text-transparent">AHELP</span>
             </a>
         </div>
-        <div>
+        <div class="flex items-center space-x-4">
+            <button id="dark-mode-toggle" class="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors text-gray-700 dark:text-gray-200" aria-label="Toggle dark mode">
+                <svg id="icon-moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.718 9.718 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 009.002-5.998z" /></svg>
+                <svg id="icon-sun" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="w-6 h-6 hidden"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z" /></svg>
+            </button>
             <a href="index.html" class="text-gray-600 hover:text-purple-600 text-sm dark-mode:text-gray-300">← Back to Home</a>
         </div>
     </nav>
@@ -392,5 +396,6 @@
             window.location.href = 'dashboard.html';
         });
     </script>
+    <script src="dark-mode.js"></script>
 </body>
 </html>

--- a/home.html
+++ b/home.html
@@ -33,7 +33,11 @@
         <img src="Help (6).png" alt="AHELP Logo" class="h-28 w-auto" />
       </a>
     </div>
-    <div class="space-x-4 text-sm">
+    <div class="flex items-center space-x-4 text-sm">
+      <button id="dark-mode-toggle" class="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors text-gray-700 dark:text-gray-200" aria-label="Toggle dark mode">
+        <svg id="icon-moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.718 9.718 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 009.002-5.998z" /></svg>
+        <svg id="icon-sun" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="w-6 h-6 hidden"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z" /></svg>
+      </button>
       <a href="login.html" class="text-1xl font-extrabold bg-gradient-to-r from-purple-400 to-orange-300 bg-clip-text text-transparent">Login</a>
       <a href="signup.html" class="text-1xl font-extrabold bg-gradient-to-r from-purple-400 to-orange-300 bg-clip-text text-transparent">Sign Up</a>
     </div>
@@ -116,5 +120,6 @@
   <footer class="text-center py-8 text-sm text-gray-500 dark-mode:text-gray-400">
     &copy; 2025 AHELP – Arkansas Healthy Employee Lifestyle Program
   </footer>
+  <script src="dark-mode.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -69,12 +69,18 @@
                 <a href="#progress" class="text-1xl font-extrabold bg-gradient-to-r from-purple-400 to-orange-300 bg-clip-text text-transparent">Activity</a>
                 <a href="login.html" class="text-1xl font-extrabold bg-gradient-to-r from-purple-400 to-orange-300 bg-clip-text text-transparent">Login</a>
             </div>
-            <!-- Mobile menu button -->
-            <button id="menu-btn" class="md:hidden text-gray-700 focus:outline-none">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
-                </svg>
-            </button>
+            <div class="flex items-center space-x-4">
+                <button id="dark-mode-toggle" class="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors text-gray-700 dark:text-gray-200" aria-label="Toggle dark mode">
+                    <svg id="icon-moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.718 9.718 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 009.002-5.998z" /></svg>
+                    <svg id="icon-sun" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="w-6 h-6 hidden"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z" /></svg>
+                </button>
+                <!-- Mobile menu button -->
+                <button id="menu-btn" class="md:hidden text-gray-700 focus:outline-none">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+                    </svg>
+                </button>
+            </div>
         </div>
         <!-- Mobile menu (hidden by default) -->
         <div id="mobile-menu" class="md:hidden hidden px-4 pb-4">
@@ -256,15 +262,10 @@
     </script>
     <!-- Back to Top Button -->
     <button id="back-to-top" class="hidden fixed bottom-6 right-6 p-3 rounded-full bg-purple-500 text-white shadow-lg" aria-label="Back to top">↑</button>
-    <!-- Persistence & Back-to-Top Script -->
+    <script src="dark-mode.js"></script>
+    <!-- Back-to-Top Script -->
     <script>
       document.addEventListener('DOMContentLoaded', function() {
-        // Apply saved dark mode from localStorage if enabled
-        try {
-          if (localStorage.getItem('darkMode') === 'true') {
-            document.body.classList.add('dark-mode');
-          }
-        } catch (e) {}
         const backBtn = document.getElementById('back-to-top');
         window.addEventListener('scroll', function() {
           if (window.scrollY > 200) {

--- a/login.html
+++ b/login.html
@@ -48,6 +48,14 @@
             border-color: #475569 !important;
         }
     </style>
+    <script>
+        try {
+            if (localStorage.getItem('darkMode') === 'true') {
+                document.documentElement.classList.add('dark-mode');
+                document.body.classList.add('dark-mode');
+            }
+        } catch (e) {}
+    </script>
 </head>
 <body class="bg-gradient-to-r from-purple-200 to-orange-200">
     <!-- Top navigation bar with logo and back link -->
@@ -57,7 +65,11 @@
                 <img src="Help (6).png" alt="AHELP logo" class="h-28 w-auto">
             </a>
         </div>
-        <div>
+        <div class="flex items-center space-x-4">
+            <button id="dark-mode-toggle" class="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors text-gray-700 dark:text-gray-200" aria-label="Toggle dark mode">
+                <svg id="icon-moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.718 9.718 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 009.002-5.998z" /></svg>
+                <svg id="icon-sun" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="w-6 h-6 hidden"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z" /></svg>
+            </button>
             <a href="index.html" class="text-gray-600 hover:text-purple-600 text-sm">← Back to Home</a>
         </div>
     </nav>
@@ -192,15 +204,10 @@
     </script>
     <!-- Back to Top Button -->
     <button id="back-to-top" class="hidden fixed bottom-6 right-6 p-3 rounded-full bg-purple-500 text-white shadow-lg" aria-label="Back to top">↑</button>
-    <!-- Persistence & Back‑to‑Top Script -->
+    <script src="dark-mode.js"></script>
+    <!-- Back‑to‑Top Script -->
     <script>
       document.addEventListener('DOMContentLoaded', function() {
-        // Apply saved dark mode across pages
-        try {
-          if (localStorage.getItem('darkMode') === 'true') {
-            document.body.classList.add('dark-mode');
-          }
-        } catch (e) {}
         const backBtn = document.getElementById('back-to-top');
         window.addEventListener('scroll', function() {
           if (window.scrollY > 200) {

--- a/profile.html
+++ b/profile.html
@@ -36,6 +36,14 @@
         }
         html { scroll-behavior: smooth; }
     </style>
+    <script>
+        try {
+            if (localStorage.getItem('darkMode') === 'true') {
+                document.documentElement.classList.add('dark-mode');
+                document.body.classList.add('dark-mode');
+            }
+        } catch (e) {}
+    </script>
 </head>
 <body class="bg-gray-50">
     <!-- Navigation -->
@@ -43,6 +51,7 @@
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center justify-between">
             <div class="flex items-center space-x-2">
                 <img src="Help (6).png" alt="AHELP logo" class="h-28 w-auto">
+            </div>
             <div class="hidden md:flex items-center space-x-8">
                 <a href="home.html" class="text-1xl font-extrabold bg-gradient-to-r from-purple-400 to-orange-300 bg-clip-text text-transparent">Home</a>
                 <!-- Added Assessment link -->
@@ -56,11 +65,17 @@
                 <a href="settings.html" class="text-1xl font-extrabold bg-gradient-to-r from-purple-400 to-orange-300 bg-clip-text text-transparent">Settings</a>
                 <a href="redeem.html" class="text-1xl font-extrabold bg-gradient-to-r from-purple-400 to-orange-300 bg-clip-text text-transparent">Redeem</a>
             </div>
-            <button id="mobile-btn" class="md:hidden text-gray-700 focus:outline-none">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-                </svg>
-            </button>
+            <div class="flex items-center space-x-4">
+                <button id="dark-mode-toggle" class="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors text-gray-700 dark:text-gray-200" aria-label="Toggle dark mode">
+                    <svg id="icon-moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.718 9.718 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 009.002-5.998z" /></svg>
+                    <svg id="icon-sun" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="w-6 h-6 hidden"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z" /></svg>
+                </button>
+                <button id="mobile-btn" class="md:hidden text-gray-700 focus:outline-none">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+                    </svg>
+                </button>
+            </div>
         </div>
         <div id="mobile-menu" class="md:hidden hidden px-4 pb-4">
             <a href="home.html" class="block py-2 text-gray-700 hover:text-purple-600">Home</a>
@@ -267,16 +282,12 @@
             alert('Profile updated successfully!');
         });
     </script>
+    <script src="dark-mode.js"></script>
     <!-- Back to Top Button -->
     <button id="back-to-top" class="hidden fixed bottom-6 right-6 p-3 rounded-full bg-purple-500 text-white shadow-lg" aria-label="Back to top">↑</button>
-    <!-- Dark Mode Persistence & Back‑to‑Top Script -->
+    <!-- Back‑to‑Top Script -->
     <script>
       document.addEventListener('DOMContentLoaded', function() {
-        try {
-          if (localStorage.getItem('darkMode') === 'true') {
-            document.body.classList.add('dark-mode');
-          }
-        } catch (e) {}
         const backBtn = document.getElementById('back-to-top');
         window.addEventListener('scroll', function() {
           if (window.scrollY > 200) {

--- a/progress.html
+++ b/progress.html
@@ -75,12 +75,18 @@
                 <a href="settings.html" class="text-1xl font-extrabold bg-gradient-to-r from-purple-400 to-orange-300 bg-clip-text text-transparent">Settings</a>
                 <a href="redeem.html" class="text-1xl font-extrabold bg-gradient-to-r from-purple-400 to-orange-300 bg-clip-text text-transparent">Redeem</a>
             </div>
-            <!-- Mobile menu toggle -->
-            <button id="mobile-menu-button" class="md:hidden text-gray-700 focus:outline-none">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-                </svg>
-            </button>
+            <div class="flex items-center space-x-4">
+                <button id="dark-mode-toggle" class="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors text-gray-700 dark:text-gray-200" aria-label="Toggle dark mode">
+                    <svg id="icon-moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.718 9.718 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 009.002-5.998z" /></svg>
+                    <svg id="icon-sun" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="w-6 h-6 hidden"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z" /></svg>
+                </button>
+                <!-- Mobile menu toggle -->
+                <button id="mobile-menu-button" class="md:hidden text-gray-700 focus:outline-none">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+                    </svg>
+                </button>
+            </div>
         </div>
         <!-- Mobile menu items -->
         <div id="mobile-menu" class="md:hidden hidden px-4 pb-4">
@@ -261,26 +267,22 @@
     </script>
     <!-- Back to Top Button -->
     <button id="back-to-top" class="hidden fixed bottom-6 right-6 p-3 rounded-full bg-purple-500 text-white shadow-lg" aria-label="Back to top">↑</button>
-    <!-- Dark Mode Persistence & Back‑to‑Top Script -->
-    <script>
-      document.addEventListener('DOMContentLoaded', function() {
-        try {
-          if (localStorage.getItem('darkMode') === 'true') {
-            document.body.classList.add('dark-mode');
-          }
-        } catch (e) {}
-        const backBtn = document.getElementById('back-to-top');
-        window.addEventListener('scroll', function() {
-          if (window.scrollY > 200) {
-            backBtn.classList.remove('hidden');
-          } else {
-            backBtn.classList.add('hidden');
-          }
+      <script src="dark-mode.js"></script>
+      <!-- Back‑to‑Top Script -->
+      <script>
+        document.addEventListener('DOMContentLoaded', function() {
+          const backBtn = document.getElementById('back-to-top');
+          window.addEventListener('scroll', function() {
+            if (window.scrollY > 200) {
+              backBtn.classList.remove('hidden');
+            } else {
+              backBtn.classList.add('hidden');
+            }
+          });
+          backBtn.addEventListener('click', function() {
+            window.scrollTo({ top: 0, behavior: 'smooth' });
+          });
         });
-        backBtn.addEventListener('click', function() {
-          window.scrollTo({ top: 0, behavior: 'smooth' });
-        });
-      });
-    </script>
+      </script>
 </body>
 </html>

--- a/redeem.html
+++ b/redeem.html
@@ -81,11 +81,17 @@
                 <a href="settings.html" class="text-1xl font-extrabold bg-gradient-to-r from-purple-400 to-orange-300 bg-clip-text text-transparent">Settings</a>
                 <a href="redeem.html" class="text-purple-600 font-semibold">Redeem</a>
             </div>
-            <button id="mobile-btn" class="md:hidden text-gray-700 focus:outline-none">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-                </svg>
-            </button>
+            <div class="flex items-center space-x-4">
+                <button id="dark-mode-toggle" class="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors text-gray-700 dark:text-gray-200" aria-label="Toggle dark mode">
+                    <svg id="icon-moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.718 9.718 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 009.002-5.998z" /></svg>
+                    <svg id="icon-sun" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="w-6 h-6 hidden"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z" /></svg>
+                </button>
+                <button id="mobile-btn" class="md:hidden text-gray-700 focus:outline-none">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+                    </svg>
+                </button>
+            </div>
         </div>
         <div id="mobile-menu" class="md:hidden hidden px-4 pb-4">
             <a href="home.html" class="block py-2 text-gray-700 hover:text-purple-600">Home</a>
@@ -213,16 +219,12 @@
             });
         });
     </script>
+    <script src="dark-mode.js"></script>
     <!-- Back to Top Button -->
     <button id="back-to-top" class="hidden fixed bottom-6 right-6 p-3 rounded-full bg-purple-500 text-white shadow-lg" aria-label="Back to top">↑</button>
-    <!-- Dark Mode Persistence & Back‑to‑Top Script -->
+    <!-- Back‑to‑Top Script -->
     <script>
       document.addEventListener('DOMContentLoaded', function() {
-        try {
-          if (localStorage.getItem('darkMode') === 'true') {
-            document.body.classList.add('dark-mode');
-          }
-        } catch (e) {}
         const backBtn = document.getElementById('back-to-top');
         window.addEventListener('scroll', function() {
           if (window.scrollY > 200) {

--- a/resources.html
+++ b/resources.html
@@ -81,11 +81,17 @@
                 <a href="settings.html" class="text-1xl font-extrabold bg-gradient-to-r from-purple-400 to-orange-300 bg-clip-text text-transparent">Settings</a>
                 <a href="redeem.html" class="text-1xl font-extrabold bg-gradient-to-r from-purple-400 to-orange-300 bg-clip-text text-transparent">Redeem</a>
             </div>
-            <button id="mobile-btn" class="md:hidden text-gray-700 focus:outline-none">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-                </svg>
-            </button>
+            <div class="flex items-center space-x-4">
+                <button id="dark-mode-toggle" class="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors text-gray-700 dark:text-gray-200" aria-label="Toggle dark mode">
+                    <svg id="icon-moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.718 9.718 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 009.002-5.998z" /></svg>
+                    <svg id="icon-sun" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="w-6 h-6 hidden"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z" /></svg>
+                </button>
+                <button id="mobile-btn" class="md:hidden text-gray-700 focus:outline-none">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+                    </svg>
+                </button>
+            </div>
         </div>
         <div id="mobile-menu" class="md:hidden hidden px-4 pb-4">
             <a href="home.html" class="block py-2 text-gray-700 hover:text-purple-600">Home</a>
@@ -214,6 +220,7 @@
         <div class="mt-8 text-center text-gray-500">© 2025 Arkansas Shared Administrative Services. All rights reserved.</div>
     </footer>
 
+    <script src="dark-mode.js"></script>
     <!-- Mobile menu script -->
     <script>
         document.getElementById('mobile-btn').addEventListener('click', () => {
@@ -222,14 +229,9 @@
     </script>
     <!-- Back to Top Button -->
     <button id="back-to-top" class="hidden fixed bottom-6 right-6 p-3 rounded-full bg-purple-500 text-white shadow-lg" aria-label="Back to top">↑</button>
-    <!-- Dark Mode Persistence & Back‑to‑Top Script -->
+    <!-- Back‑to‑Top Script -->
     <script>
       document.addEventListener('DOMContentLoaded', function() {
-        try {
-          if (localStorage.getItem('darkMode') === 'true') {
-            document.body.classList.add('dark-mode');
-          }
-        } catch (e) {}
         const backBtn = document.getElementById('back-to-top');
         window.addEventListener('scroll', function() {
           if (window.scrollY > 200) {

--- a/settings.html
+++ b/settings.html
@@ -38,6 +38,14 @@
         }
         html { scroll-behavior: smooth; }
     </style>
+    <script>
+        try {
+            if (localStorage.getItem('darkMode') === 'true') {
+                document.documentElement.classList.add('dark-mode');
+                document.body.classList.add('dark-mode');
+            }
+        } catch (e) {}
+    </script>
 </head>
 <body class="bg-gray-50" id="settings-body">
     <!-- Navigation -->
@@ -59,11 +67,17 @@
                 <a href="settings.html" class="text-purple-600 font-semibold">Settings</a>
                 <a href="redeem.html" class="text-1xl font-extrabold bg-gradient-to-r from-purple-400 to-orange-300 bg-clip-text text-transparent">Redeem</a>
             </div>
-            <button id="mobile-btn" class="md:hidden text-gray-700 focus:outline-none">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-                </svg>
-            </button>
+            <div class="flex items-center space-x-4">
+                <button id="dark-mode-toggle" class="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors text-gray-700 dark:text-gray-200" aria-label="Toggle dark mode">
+                    <svg id="icon-moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.718 9.718 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 009.002-5.998z" /></svg>
+                    <svg id="icon-sun" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="w-6 h-6 hidden"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z" /></svg>
+                </button>
+                <button id="mobile-btn" class="md:hidden text-gray-700 focus:outline-none">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+                    </svg>
+                </button>
+            </div>
         </div>
         <div id="mobile-menu" class="md:hidden hidden px-4 pb-4">
             <a href="home.html" class="block py-2 text-gray-700 hover:text-purple-600">Home</a>
@@ -150,10 +164,10 @@
 
         // Load settings from localStorage
         document.addEventListener('DOMContentLoaded', () => {
-            const notificationsEnabled = localStorage.getItem('settingsNotifications') === 'true';
-            // persist dark mode in a global key for all pages
-            const darkModeEnabled = localStorage.getItem('darkMode') === 'true';
-            const deviceSyncEnabled = localStorage.getItem('settingsDeviceSync') === 'true';
+              const notificationsEnabled = localStorage.getItem('settingsNotifications') === 'true';
+              // persist dark mode in a global key for all pages
+              const darkModeEnabled = localStorage.getItem('darkMode') === 'true';
+              const deviceSyncEnabled = localStorage.getItem('settingsDeviceSync') === 'true';
             const stepsGoal = localStorage.getItem('settingsStepsGoal') || '';
             const notificationsEl = document.getElementById('notifications');
             const darkModeEl = document.getElementById('darkMode');
@@ -163,10 +177,8 @@
             if (darkModeEl) darkModeEl.checked = darkModeEnabled;
             if (deviceSyncEl) deviceSyncEl.checked = deviceSyncEnabled;
             if (stepsGoalEl) stepsGoalEl.value = stepsGoal;
-            if (darkModeEnabled) {
-                document.body.classList.add('dark-mode');
-            }
-        });
+              // dark mode classes handled by shared script
+          });
 
         // Save preferences
         document.getElementById('settings-form').addEventListener('submit', e => {
@@ -180,38 +192,34 @@
             localStorage.setItem('darkMode', darkMode);
             localStorage.setItem('settingsDeviceSync', deviceSync);
             localStorage.setItem('settingsStepsGoal', stepsGoal);
-            // Apply dark mode immediately
-            document.body.classList.toggle('dark-mode', darkMode);
+              // Apply dark mode immediately
+              document.body.classList.toggle('dark-mode', darkMode);
+              document.documentElement.classList.toggle('dark-mode', darkMode);
             // Optionally show a message if device sync is enabled
             if (deviceSync) {
                 alert('Device sync enabled. Your fitness device data will be synced automatically.');
             }
             alert('Settings saved successfully!');
         });
-    </script>
-    <!-- Back to Top Button -->
-    <button id="back-to-top" class="hidden fixed bottom-6 right-6 p-3 rounded-full bg-purple-500 text-white shadow-lg" aria-label="Back to top">↑</button>
-    <!-- Dark Mode Persistence & Back‑to‑Top Script -->
-    <script>
-      document.addEventListener('DOMContentLoaded', function() {
-        // Apply saved dark mode across pages
-        try {
-          if (localStorage.getItem('darkMode') === 'true') {
-            document.body.classList.add('dark-mode');
-          }
-        } catch (e) {}
-        const backBtn = document.getElementById('back-to-top');
-        window.addEventListener('scroll', function() {
-          if (window.scrollY > 200) {
-            backBtn.classList.remove('hidden');
-          } else {
-            backBtn.classList.add('hidden');
-          }
+      </script>
+      <script src="dark-mode.js"></script>
+      <!-- Back to Top Button -->
+      <button id="back-to-top" class="hidden fixed bottom-6 right-6 p-3 rounded-full bg-purple-500 text-white shadow-lg" aria-label="Back to top">↑</button>
+      <!-- Back‑to‑Top Script -->
+      <script>
+        document.addEventListener('DOMContentLoaded', function() {
+          const backBtn = document.getElementById('back-to-top');
+          window.addEventListener('scroll', function() {
+            if (window.scrollY > 200) {
+              backBtn.classList.remove('hidden');
+            } else {
+              backBtn.classList.add('hidden');
+            }
+          });
+          backBtn.addEventListener('click', function() {
+            window.scrollTo({ top: 0, behavior: 'smooth' });
+          });
         });
-        backBtn.addEventListener('click', function() {
-          window.scrollTo({ top: 0, behavior: 'smooth' });
-        });
-      });
-    </script>
+      </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add reusable `dark-mode.js` to manage theme state
- place dark mode toggle in navbars across public and admin pages
- remove page-specific dark mode code in favor of shared logic

## Testing
- `npx --yes prettier --check index.html home.html progress.html login.html challenges.html community.html resources.html profile.html settings.html redeem.html health-assessment.html admin-login.html admin-dashboard.html dashboard.html dark-mode.js` *(fails: SyntaxError: Opening tag "iframe" not terminated, SyntaxError: Unexpected closing tag "form", SyntaxError: Unexpected closing tag "nav")*

------
https://chatgpt.com/codex/tasks/task_e_68964c0acd688320b56246b4c022eabb