### PR TITLE
refactor: centralize site scripts

### DIFF
--- a/Main page.html
+++ b/Main page.html
@@ -250,5 +250,6 @@
             }
         });
     </script>
+    <script src="assets/js/main.js"></script>
 </body>
 </html>

--- a/admin-dashboard.html
+++ b/admin-dashboard.html
@@ -40,15 +40,6 @@
             border-color: #475569 !important;
         }
     </style>
-    <!-- Apply dark mode before page renders -->
-    <script>
-        try {
-            if (localStorage.getItem('darkMode') === 'true') {
-                document.documentElement.classList.add('dark-mode');
-                document.body?.classList.add('dark-mode');
-            }
-        } catch (e) {}
-    </script>
 </head>
 <body class="bg-gray-50 min-h-screen flex flex-col">
     <!-- Navigation bar -->
@@ -910,5 +901,6 @@
             showTab('analytics');
         });
     </script>
+    <script src="assets/js/main.js"></script>
 </body>
 </html>

--- a/admin-login.html
+++ b/admin-login.html
@@ -38,15 +38,6 @@
             border-color: #475569 !important;
         }
     </style>
-    <!-- Apply dark mode before page renders -->
-    <script>
-        try {
-            if (localStorage.getItem('darkMode') === 'true') {
-                document.documentElement.classList.add('dark-mode');
-                document.body.classList.add('dark-mode');
-            }
-        } catch (e) {}
-    </script>
 </head>
 <body class="bg-gray-50 min-h-screen flex flex-col">
     <!-- Navigation bar -->
@@ -123,5 +114,6 @@
             }
         });
     </script>
+    <script src="assets/js/main.js"></script>
 </body>
 </html>

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,74 @@
+// Main site-wide JavaScript
+// Handles mobile navigation toggling, back-to-top behaviour, and dark mode persistence
+
+document.addEventListener('DOMContentLoaded', () => {
+  // Dark mode persistence
+  let isDark = false;
+  try {
+    isDark = localStorage.getItem('darkMode') === 'true';
+  } catch (e) {}
+  if (isDark) {
+    document.documentElement.classList.add('dark-mode');
+    document.body.classList.add('dark-mode');
+  }
+  if (window.userData) {
+    window.userData.darkMode = isDark;
+  }
+  toggleIcons(isDark);
+
+  // Dark mode toggle handler
+  const darkToggle = document.getElementById('dark-mode-toggle');
+  if (darkToggle) {
+    darkToggle.addEventListener('click', () => {
+      const nowDark = !document.body.classList.contains('dark-mode');
+      document.body.classList.toggle('dark-mode', nowDark);
+      document.documentElement.classList.toggle('dark-mode', nowDark);
+      try { localStorage.setItem('darkMode', nowDark); } catch (e) {}
+      if (window.userData) { window.userData.darkMode = nowDark; }
+      toggleIcons(nowDark);
+      if (typeof showEnhancedNotification === 'function') {
+        showEnhancedNotification(nowDark ? 'Dark mode activated!' : 'Light mode activated!', 'info');
+      }
+    });
+  }
+
+  // Mobile menu toggle
+  const menuBtn = document.getElementById('menu-btn') ||
+                  document.getElementById('mobile-btn') ||
+                  document.getElementById('mobile-menu-button');
+  const mobileMenu = document.getElementById('mobile-menu');
+  if (menuBtn && mobileMenu) {
+    menuBtn.addEventListener('click', () => {
+      mobileMenu.classList.toggle('hidden');
+    });
+  }
+
+  // Back to top button
+  const backBtn = document.getElementById('back-to-top');
+  if (backBtn) {
+    window.addEventListener('scroll', () => {
+      if (window.scrollY > 200) {
+        backBtn.classList.remove('hidden');
+      } else {
+        backBtn.classList.add('hidden');
+      }
+    });
+    backBtn.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  }
+});
+
+function toggleIcons(isDark) {
+  const iconMoon = document.getElementById('icon-moon');
+  const iconSun = document.getElementById('icon-sun');
+  if (iconMoon && iconSun) {
+    if (isDark) {
+      iconMoon.classList.add('hidden');
+      iconSun.classList.remove('hidden');
+    } else {
+      iconMoon.classList.remove('hidden');
+      iconSun.classList.add('hidden');
+    }
+  }
+}

--- a/challenges.html
+++ b/challenges.html
@@ -57,15 +57,6 @@
         }
     </style>
 
-    <!-- Apply dark mode class early before page renders to prevent flash of unstyled content -->
-    <script>
-      try {
-        if (localStorage.getItem('darkMode') === 'true') {
-          document.documentElement.classList.add('dark-mode');
-          document.body.classList.add('dark-mode');
-        }
-      } catch (e) {}
-    </script>
 </head>
 <body class="bg-gray-50">
     <!-- Navigation -->
@@ -203,35 +194,8 @@
         <div class="mt-8 text-center text-gray-500">© 2025 Arkansas Shared Administrative Services. All rights reserved.</div>
     </footer>
 
-    <!-- Mobile menu script -->
-    <script>
-        document.getElementById('mobile-btn').addEventListener('click', () => {
-            document.getElementById('mobile-menu').classList.toggle('hidden');
-        });
-    </script>
     <!-- Back to Top Button -->
     <button id="back-to-top" class="hidden fixed bottom-6 right-6 p-3 rounded-full bg-purple-500 text-white shadow-lg" aria-label="Back to top">↑</button>
-    <!-- Dark Mode Persistence & Back‑to‑Top Script -->
-    <script>
-      document.addEventListener('DOMContentLoaded', function() {
-        // Apply saved dark mode from localStorage if enabled
-        try {
-          if (localStorage.getItem('darkMode') === 'true') {
-            document.body.classList.add('dark-mode');
-          }
-        } catch (e) {}
-        const backBtn = document.getElementById('back-to-top');
-        window.addEventListener('scroll', function() {
-          if (window.scrollY > 200) {
-            backBtn.classList.remove('hidden');
-          } else {
-            backBtn.classList.add('hidden');
-          }
-        });
-        backBtn.addEventListener('click', function() {
-          window.scrollTo({ top: 0, behavior: 'smooth' });
-        });
-      });
-    </script>
+<script src="assets/js/main.js"></script>
 </body>
 </html>

--- a/community.html
+++ b/community.html
@@ -39,15 +39,6 @@
             border-color: #475569 !important;
         }
     </style>
-    <!-- Apply dark mode class early before page renders to prevent flash -->
-    <script>
-        try {
-            if (localStorage.getItem('darkMode') === 'true') {
-                document.documentElement.classList.add('dark-mode');
-                document.body.classList.add('dark-mode');
-            }
-        } catch (e) {}
-    </script>
 </head>
 <body class="bg-gray-50">
     <!-- Navigation -->
@@ -158,55 +149,24 @@
         <div class="mt-8 text-center text-gray-500">© 2025 Arkansas Shared Administrative Services. All rights reserved.</div>
     </footer>
 
-    <!-- Mobile menu script -->
-    <script>
-        document.getElementById('mobile-btn').addEventListener('click', () => {
-            document.getElementById('mobile-menu').classList.toggle('hidden');
-        });
-    </script>
-    <!-- Back to Top Button -->
-    <button id="back-to-top" class="hidden fixed bottom-6 right-6 p-3 rounded-full bg-purple-500 text-white shadow-lg" aria-label="Back to top">↑</button>
-    <!-- Dark Mode Persistence & Back‑to‑Top Script -->
-    <script>
-      document.addEventListener('DOMContentLoaded', function() {
-        try {
-          if (localStorage.getItem('darkMode') === 'true') {
-            document.body.classList.add('dark-mode');
-          }
-        } catch (e) {}
-        const backBtn = document.getElementById('back-to-top');
-        window.addEventListener('scroll', function() {
-          if (window.scrollY > 200) {
-            backBtn.classList.remove('hidden');
-          } else {
-            backBtn.classList.add('hidden');
-          }
-        });
-        backBtn.addEventListener('click', function() {
-          window.scrollTo({ top: 0, behavior: 'smooth' });
-        });
-      });
-    </script>
-      <!-- Scripts -->
-  <script>
-        document.getElementById('mobile-btn').addEventListener('click', () => {
-            document.getElementById('mobile-menu').classList.toggle('hidden');
-        });
+<!-- Back to Top Button -->
+<button id="back-to-top" class="hidden fixed bottom-6 right-6 p-3 rounded-full bg-purple-500 text-white shadow-lg" aria-label="Back to top">↑</button>
+<!-- Scripts -->
+<script>
+    document.getElementById('postForm').addEventListener('submit', function (e) {
+        e.preventDefault();
+        const title = document.getElementById('postTitle').value.trim();
+        const description = document.getElementById('postDescription').value.trim();
+        const distance = document.getElementById('postDistance').value.trim();
+        const duration = document.getElementById('postDuration').value.trim();
+        const activityType = document.getElementById('postActivityType').value;
+        const imageFile = document.getElementById('postImage').files[0];
 
-        document.getElementById('postForm').addEventListener('submit', function (e) {
-            e.preventDefault();
-            const title = document.getElementById('postTitle').value.trim();
-            const description = document.getElementById('postDescription').value.trim();
-            const distance = document.getElementById('postDistance').value.trim();
-            const duration = document.getElementById('postDuration').value.trim();
-            const activityType = document.getElementById('postActivityType').value;
-            const imageFile = document.getElementById('postImage').files[0];
-
-            const reader = new FileReader();
-            reader.onload = function () {
-                const post = document.createElement('div');
-                post.className = 'bg-white p-6 rounded-lg shadow dark-mode:bg-gray-700';
-                post.innerHTML = `
+        const reader = new FileReader();
+        reader.onload = function () {
+            const post = document.createElement('div');
+            post.className = 'bg-white p-6 rounded-lg shadow dark-mode:bg-gray-700';
+            post.innerHTML = `
                     <h3 class="font-semibold text-lg text-gray-800 dark-mode:text-white">You</h3>
                     <p class="text-gray-600 dark-mode:text-gray-300 mt-2">${description}</p>
                     ${activityType ? `<p class="text-sm text-purple-500 mt-1">Activity: ${activityType}</p>` : ''}
@@ -215,35 +175,16 @@
                     ${reader.result ? `<img src="${reader.result}" alt="Uploaded image" class="mt-4 rounded">` : ''}
                     <span class="text-xs text-gray-400 block mt-2">Just now</span>
                 `;
-                document.getElementById('postFeed').prepend(post);
-                document.getElementById('postForm').reset();
-            };
-            if (imageFile) {
-                reader.readAsDataURL(imageFile);
-            } else {
-                reader.onload();
-            }
-        });
-
-        // Dark mode and back to top
-        document.addEventListener('DOMContentLoaded', function () {
-            try {
-                if (localStorage.getItem('darkMode') === 'true') {
-                    document.body.classList.add('dark-mode');
-                }
-            } catch (e) {}
-            const backBtn = document.getElementById('back-to-top');
-            window.addEventListener('scroll', function () {
-                if (window.scrollY > 200) {
-                    backBtn.classList.remove('hidden');
-                } else {
-                    backBtn.classList.add('hidden');
-                }
-            });
-            backBtn.addEventListener('click', function () {
-                window.scrollTo({ top: 0, behavior: 'smooth' });
-            });
-        });
-    </script>
+            document.getElementById('postFeed').prepend(post);
+            document.getElementById('postForm').reset();
+        };
+        if (imageFile) {
+            reader.readAsDataURL(imageFile);
+        } else {
+            reader.onload();
+        }
+    });
+</script>
+<script src="assets/js/main.js"></script>
 </body>
 </html>

--- a/dashboard.html
+++ b/dashboard.html
@@ -1588,20 +1588,6 @@
             if (userNameEl) {
                 userNameEl.textContent = userData.name;
             }
-            // Apply previously saved dark mode state
-            try {
-                const savedDark = localStorage.getItem('darkMode');
-                if (savedDark === 'true') {
-                    userData.darkMode = true;
-                    document.body.classList.add('dark-mode');
-                    const iconMoon = document.getElementById('icon-moon');
-                    const iconSun  = document.getElementById('icon-sun');
-                    if (iconMoon && iconSun) {
-                        iconMoon.classList.add('hidden');
-                        iconSun.classList.remove('hidden');
-                    }
-                }
-            } catch (e) {}
             // Immediately update the dashboard stats and visualisations when the page loads
             if (typeof updateDisplay === 'function') {
                 updateDisplay();
@@ -1713,30 +1699,6 @@
             });
         });
 
-        // Dark mode toggle
-        document.getElementById('dark-mode-toggle').addEventListener('click', () => {
-            // Flip the darkMode flag and apply/remove the dark mode class on the body
-            userData.darkMode = !userData.darkMode;
-            document.body.classList.toggle('dark-mode', userData.darkMode);
-            // Persist the dark mode preference so other pages stay in sync
-            try {
-                localStorage.setItem('darkMode', userData.darkMode);
-            } catch (e) {}
-
-            // Toggle visibility of the moon and sun icons; in light mode show the moon (meaning you can switch to dark)
-            const iconMoon = document.getElementById('icon-moon');
-            const iconSun  = document.getElementById('icon-sun');
-            if (userData.darkMode) {
-                iconMoon.classList.add('hidden');
-                iconSun.classList.remove('hidden');
-            } else {
-                iconMoon.classList.remove('hidden');
-                iconSun.classList.add('hidden');
-            }
-
-            // Show a toast letting the user know which mode is active
-            showEnhancedNotification(userData.darkMode ? 'Dark mode activated!' : 'Light mode activated!', 'info');
-        });
 
         // Voice command (demo)
         document.getElementById('voice-command').addEventListener('click', () => {
@@ -3112,19 +3074,6 @@
         // Initialise personalised plan display and yearly HRA reminders
         initHealthAssessmentFeatures();
 
-        // Back to top functionality
-        const backToTopBtn = document.getElementById('back-to-top');
-        window.addEventListener('scroll', () => {
-            if (window.scrollY > 300) {
-                backToTopBtn.classList.remove('hidden');
-            } else {
-                backToTopBtn.classList.add('hidden');
-            }
-        });
-        backToTopBtn.addEventListener('click', () => {
-            window.scrollTo({ top: 0, behavior: 'smooth' });
-        });
-    </script>
 
     <!-- Footer -->
     <footer class="bg-white py-8">
@@ -3156,12 +3105,7 @@
         </div>
         <div class="mt-8 text-center text-gray-500">© 2025 Arkansas Shared Administrative Services. All rights reserved.</div>
     </footer>
+    <script src="assets/js/main.js"></script>
+</body>
 
-<!-- Script to handle mobile navigation toggle on the dashboard -->
-<script>
-    document.getElementById('mobile-menu-button').addEventListener('click', () => {
-        document.getElementById('mobile-menu').classList.toggle('hidden');
-    });
-</script>
-<script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML="window.__CF$cv$params={r:'9685e464f31dbd17',t:'MTc1NDA1NzE0NS4wMDAwMDA='};var a=document.createElement('script');a.nonce='';a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);";b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script></body>
 </html>

--- a/health-assessment.html
+++ b/health-assessment.html
@@ -46,14 +46,6 @@
             border-color: #475569 !important;
         }
     </style>
-    <!-- Early dark-mode application -->
-    <script>
-        // Immediately apply dark mode if user preference is stored
-        if (localStorage.getItem('darkMode') === 'true') {
-            document.documentElement.classList.add('dark-mode');
-            document.body.classList.add('dark-mode');
-        }
-    </script>
 </head>
 <body class="bg-gray-50 transition-all duration-500">
     <!-- Navigation -->
@@ -260,21 +252,6 @@
     <!-- Back to Top Button -->
     <button id="back-to-top" class="hidden fixed bottom-6 right-6 p-3 rounded-full bg-purple-500 text-white shadow-lg" aria-label="Back to top">↑</button>
     <!-- Scripts -->
-    <script>
-        document.addEventListener('DOMContentLoaded', function() {
-            // Back to top button
-            const backToTopBtn = document.getElementById('back-to-top');
-            window.addEventListener('scroll', () => {
-                if (window.scrollY > 300) {
-                    backToTopBtn.classList.remove('hidden');
-                } else {
-                    backToTopBtn.classList.add('hidden');
-                }
-            });
-            backToTopBtn.addEventListener('click', () => {
-                window.scrollTo({ top: 0, behavior: 'smooth' });
-            });
-        });
         // Handle HRA form submission
         const form = document.getElementById('health-form');
         form.addEventListener('submit', function(e) {
@@ -392,5 +369,6 @@
             window.location.href = 'dashboard.html';
         });
     </script>
+    <script src="assets/js/main.js"></script>
 </body>
 </html>

--- a/home.html
+++ b/home.html
@@ -18,12 +18,6 @@
       color: #e2e8f0 !important;
     }
   </style>
-  <script>
-    if (localStorage.getItem('darkMode') === 'true') {
-      document.documentElement.classList.add('dark-mode');
-      document.body.classList.add('dark-mode');
-    }
-  </script>
 </head>
 <body class="bg-gray-50 transition-all duration-500">
   <!-- Navigation Bar -->
@@ -116,5 +110,6 @@
   <footer class="text-center py-8 text-sm text-gray-500 dark-mode:text-gray-400">
     &copy; 2025 AHELP – Arkansas Healthy Employee Lifestyle Program
   </footer>
+<script src="assets/js/main.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -44,15 +44,6 @@
         }
     </style>
 
-    <!-- Apply dark mode class early before page renders to prevent flash -->
-    <script>
-        try {
-            if (localStorage.getItem('darkMode') === 'true') {
-                document.documentElement.classList.add('dark-mode');
-                document.body.classList.add('dark-mode');
-            }
-        } catch (e) {}
-    </script>
 </head>
 <body class="text-gray-700 antialiased">
     <!-- Navigation Bar -->
@@ -219,12 +210,6 @@
 
     <!-- Scripts -->
     <script>
-        // Mobile navigation toggle
-        const menuBtn = document.getElementById('menu-btn');
-        const mobileMenu = document.getElementById('mobile-menu');
-        menuBtn.addEventListener('click', () => {
-            mobileMenu.classList.toggle('hidden');
-        });
 
         // BMI Calculator removed; the new Health Assessment page provides personalised guidance instead.
 
@@ -256,27 +241,6 @@
     </script>
     <!-- Back to Top Button -->
     <button id="back-to-top" class="hidden fixed bottom-6 right-6 p-3 rounded-full bg-purple-500 text-white shadow-lg" aria-label="Back to top">↑</button>
-    <!-- Persistence & Back-to-Top Script -->
-    <script>
-      document.addEventListener('DOMContentLoaded', function() {
-        // Apply saved dark mode from localStorage if enabled
-        try {
-          if (localStorage.getItem('darkMode') === 'true') {
-            document.body.classList.add('dark-mode');
-          }
-        } catch (e) {}
-        const backBtn = document.getElementById('back-to-top');
-        window.addEventListener('scroll', function() {
-          if (window.scrollY > 200) {
-            backBtn.classList.remove('hidden');
-          } else {
-            backBtn.classList.add('hidden');
-          }
-        });
-        backBtn.addEventListener('click', function() {
-          window.scrollTo({ top: 0, behavior: 'smooth' });
-        });
-      });
-    </script>
+<script src="assets/js/main.js"></script>
 </body>
 </html>

--- a/login.html
+++ b/login.html
@@ -192,27 +192,6 @@
     </script>
     <!-- Back to Top Button -->
     <button id="back-to-top" class="hidden fixed bottom-6 right-6 p-3 rounded-full bg-purple-500 text-white shadow-lg" aria-label="Back to top">↑</button>
-    <!-- Persistence & Back‑to‑Top Script -->
-    <script>
-      document.addEventListener('DOMContentLoaded', function() {
-        // Apply saved dark mode across pages
-        try {
-          if (localStorage.getItem('darkMode') === 'true') {
-            document.body.classList.add('dark-mode');
-          }
-        } catch (e) {}
-        const backBtn = document.getElementById('back-to-top');
-        window.addEventListener('scroll', function() {
-          if (window.scrollY > 200) {
-            backBtn.classList.remove('hidden');
-          } else {
-            backBtn.classList.add('hidden');
-          }
-        });
-        backBtn.addEventListener('click', function() {
-          window.scrollTo({ top: 0, behavior: 'smooth' });
-        });
-      });
-    </script>
+    <script src="assets/js/main.js"></script>
 </body>
 </html>

--- a/profile.html
+++ b/profile.html
@@ -178,10 +178,6 @@
 
     <!-- Scripts for mobile menu and profile handling -->
     <script>
-        // Mobile menu toggle
-        document.getElementById('mobile-btn').addEventListener('click', () => {
-            document.getElementById('mobile-menu').classList.toggle('hidden');
-        });
 
         // Populate profile info from localStorage if available
         document.addEventListener('DOMContentLoaded', () => {
@@ -269,26 +265,6 @@
     </script>
     <!-- Back to Top Button -->
     <button id="back-to-top" class="hidden fixed bottom-6 right-6 p-3 rounded-full bg-purple-500 text-white shadow-lg" aria-label="Back to top">↑</button>
-    <!-- Dark Mode Persistence & Back‑to‑Top Script -->
-    <script>
-      document.addEventListener('DOMContentLoaded', function() {
-        try {
-          if (localStorage.getItem('darkMode') === 'true') {
-            document.body.classList.add('dark-mode');
-          }
-        } catch (e) {}
-        const backBtn = document.getElementById('back-to-top');
-        window.addEventListener('scroll', function() {
-          if (window.scrollY > 200) {
-            backBtn.classList.remove('hidden');
-          } else {
-            backBtn.classList.add('hidden');
-          }
-        });
-        backBtn.addEventListener('click', function() {
-          window.scrollTo({ top: 0, behavior: 'smooth' });
-        });
-      });
-    </script>
+<script src="assets/js/main.js"></script>
 </body>
 </html>

--- a/progress.html
+++ b/progress.html
@@ -45,13 +45,6 @@
     </style>
 
     <!-- Apply dark mode class early before page renders to prevent flash -->
-    <script>
-        try {
-            if (localStorage.getItem('darkMode') === 'true') {
-                document.documentElement.classList.add('dark-mode');
-                document.body.classList.add('dark-mode');
-            }
-        } catch (e) {}
     </script>
 </head>
 <body class="bg-gray-50">
@@ -175,11 +168,6 @@
 
     <!-- Scripts for charts and mobile menu toggle -->
     <script>
-        // Mobile menu toggle
-        document.getElementById('mobile-menu-button').addEventListener('click', () => {
-            const menu = document.getElementById('mobile-menu');
-            menu.classList.toggle('hidden');
-        });
         
         // Data for the weekly activity chart
         const weeklyCtx = document.getElementById('weeklyChart').getContext('2d');
@@ -261,26 +249,6 @@
     </script>
     <!-- Back to Top Button -->
     <button id="back-to-top" class="hidden fixed bottom-6 right-6 p-3 rounded-full bg-purple-500 text-white shadow-lg" aria-label="Back to top">↑</button>
-    <!-- Dark Mode Persistence & Back‑to‑Top Script -->
-    <script>
-      document.addEventListener('DOMContentLoaded', function() {
-        try {
-          if (localStorage.getItem('darkMode') === 'true') {
-            document.body.classList.add('dark-mode');
-          }
-        } catch (e) {}
-        const backBtn = document.getElementById('back-to-top');
-        window.addEventListener('scroll', function() {
-          if (window.scrollY > 200) {
-            backBtn.classList.remove('hidden');
-          } else {
-            backBtn.classList.add('hidden');
-          }
-        });
-        backBtn.addEventListener('click', function() {
-          window.scrollTo({ top: 0, behavior: 'smooth' });
-        });
-      });
-    </script>
+    <script src="assets/js/main.js"></script>
 </body>
 </html>

--- a/redeem.html
+++ b/redeem.html
@@ -51,15 +51,6 @@
             border-color: #475569 !important;
         }
     </style>
-    <!-- Apply dark mode class early before page renders to prevent flash -->
-    <script>
-        try {
-            if (localStorage.getItem('darkMode') === 'true') {
-                document.documentElement.classList.add('dark-mode');
-                document.body.classList.add('dark-mode');
-            }
-        } catch (e) {}
-    </script>
 </head>
 <body class="bg-gray-50">
     <!-- Navigation -->
@@ -172,9 +163,6 @@
 
     <!-- Scripts for mobile menu and points handling -->
     <script>
-        document.getElementById('mobile-btn').addEventListener('click', () => {
-            document.getElementById('mobile-menu').classList.toggle('hidden');
-        });
 
         // Load points from localStorage or set default
         let points = parseInt(localStorage.getItem('userPoints') || '0');
@@ -215,26 +203,6 @@
     </script>
     <!-- Back to Top Button -->
     <button id="back-to-top" class="hidden fixed bottom-6 right-6 p-3 rounded-full bg-purple-500 text-white shadow-lg" aria-label="Back to top">↑</button>
-    <!-- Dark Mode Persistence & Back‑to‑Top Script -->
-    <script>
-      document.addEventListener('DOMContentLoaded', function() {
-        try {
-          if (localStorage.getItem('darkMode') === 'true') {
-            document.body.classList.add('dark-mode');
-          }
-        } catch (e) {}
-        const backBtn = document.getElementById('back-to-top');
-        window.addEventListener('scroll', function() {
-          if (window.scrollY > 200) {
-            backBtn.classList.remove('hidden');
-          } else {
-            backBtn.classList.add('hidden');
-          }
-        });
-        backBtn.addEventListener('click', function() {
-          window.scrollTo({ top: 0, behavior: 'smooth' });
-        });
-      });
-    </script>
+<script src="assets/js/main.js"></script>
 </body>
 </html>

--- a/resources.html
+++ b/resources.html
@@ -52,15 +52,6 @@
             border-color: #475569 !important;
         }
     </style>
-    <!-- Apply dark mode class early before page renders to prevent flash -->
-    <script>
-        try {
-            if (localStorage.getItem('darkMode') === 'true') {
-                document.documentElement.classList.add('dark-mode');
-                document.body.classList.add('dark-mode');
-            }
-        } catch (e) {}
-    </script>
 </head>
 <body class="bg-gray-50">
     <!-- Navigation -->
@@ -214,34 +205,8 @@
         <div class="mt-8 text-center text-gray-500">© 2025 Arkansas Shared Administrative Services. All rights reserved.</div>
     </footer>
 
-    <!-- Mobile menu script -->
-    <script>
-        document.getElementById('mobile-btn').addEventListener('click', () => {
-            document.getElementById('mobile-menu').classList.toggle('hidden');
-        });
-    </script>
-    <!-- Back to Top Button -->
-    <button id="back-to-top" class="hidden fixed bottom-6 right-6 p-3 rounded-full bg-purple-500 text-white shadow-lg" aria-label="Back to top">↑</button>
-    <!-- Dark Mode Persistence & Back‑to‑Top Script -->
-    <script>
-      document.addEventListener('DOMContentLoaded', function() {
-        try {
-          if (localStorage.getItem('darkMode') === 'true') {
-            document.body.classList.add('dark-mode');
-          }
-        } catch (e) {}
-        const backBtn = document.getElementById('back-to-top');
-        window.addEventListener('scroll', function() {
-          if (window.scrollY > 200) {
-            backBtn.classList.remove('hidden');
-          } else {
-            backBtn.classList.add('hidden');
-          }
-        });
-        backBtn.addEventListener('click', function() {
-          window.scrollTo({ top: 0, behavior: 'smooth' });
-        });
-      });
-    </script>
+<!-- Back to Top Button -->
+<button id="back-to-top" class="hidden fixed bottom-6 right-6 p-3 rounded-full bg-purple-500 text-white shadow-lg" aria-label="Back to top">↑</button>
+<script src="assets/js/main.js"></script>
 </body>
 </html>

--- a/settings.html
+++ b/settings.html
@@ -143,10 +143,6 @@
     </footer>
 
     <!-- Mobile menu & settings script -->
-    <script>
-        document.getElementById('mobile-btn').addEventListener('click', () => {
-            document.getElementById('mobile-menu').classList.toggle('hidden');
-        });
 
         // Load settings from localStorage
         document.addEventListener('DOMContentLoaded', () => {
@@ -191,27 +187,6 @@
     </script>
     <!-- Back to Top Button -->
     <button id="back-to-top" class="hidden fixed bottom-6 right-6 p-3 rounded-full bg-purple-500 text-white shadow-lg" aria-label="Back to top">↑</button>
-    <!-- Dark Mode Persistence & Back‑to‑Top Script -->
-    <script>
-      document.addEventListener('DOMContentLoaded', function() {
-        // Apply saved dark mode across pages
-        try {
-          if (localStorage.getItem('darkMode') === 'true') {
-            document.body.classList.add('dark-mode');
-          }
-        } catch (e) {}
-        const backBtn = document.getElementById('back-to-top');
-        window.addEventListener('scroll', function() {
-          if (window.scrollY > 200) {
-            backBtn.classList.remove('hidden');
-          } else {
-            backBtn.classList.add('hidden');
-          }
-        });
-        backBtn.addEventListener('click', function() {
-          window.scrollTo({ top: 0, behavior: 'smooth' });
-        });
-      });
-    </script>
+<script src="assets/js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- consolidate dark mode, mobile menu, and back-to-top behaviors into `assets/js/main.js`
- load shared script across pages and remove duplicated inline logic

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68964c0dec488320a858e400695006aa